### PR TITLE
Cache locations after pulling them from the LFRecord database

### DIFF
--- a/MistWX-i2Me/Globals.cs
+++ b/MistWX-i2Me/Globals.cs
@@ -1,0 +1,8 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace MistWX_i2Me;
+
+public static class Globals
+{
+    public static IMemoryCache LocationCache = new MemoryCache(new MemoryCacheOptions());
+}


### PR DESCRIPTION
This significantly improves I/O performance by caching location information into memory after having pulled from for the first time.